### PR TITLE
Added flags for ghostscript-gpl and xmlto in dotfiles

### DIFF
--- a/scripts/gentoo/package.use/dotfiles
+++ b/scripts/gentoo/package.use/dotfiles
@@ -53,3 +53,9 @@ x11-misc/rofi windowmode
 
 # fdm
 net-mail/fdm examples
+
+# ghostscript-gpl
+app-text/ghostscript-gpl cups
+
+# xmlto
+app-text/xmlto text


### PR DESCRIPTION
``emerge`` wanted ``cups`` flag for ``ghostscript-gpl`` and ``text`` flag for ``xmlto``. The changes are written in /script/gentoo/package.use/dotfiles since they can't be found anywhere else.

However it was not enough: After ``chezmoi apply`` there was an error where emerge can't find any ebuild that is ``virtual/libffi``:

```
Beast-PC ~/.local/share/chezmoi # chezmoi update
Already up to date.
--------------------------------------------------
--> Execute /tmp/2079493690.10-install-packages.sh...

--- Invalid atom in /etc/portage/package.use/awesome: x11-wm/awesome-4.3-r101::gentoo
--- Invalid atom in /etc/portage/package.license: LUA_SINGLE_TARGET
--- Invalid atom in /etc/portage/package.license: media-video/nvidia-video-codec-8.2.16::gentoo
--- Invalid atom in /etc/portage/package.license: x11-misc/pcmanfm-1.3.2-r1::gentoo

 * IMPORTANT: 3 news items need reading for repository 'gentoo'.
  * Use eselect news read to view new items.


  These are the packages that would be merged, in order:

  Calculating dependencies... done!

  emerge: there are no ebuilds to satisfy "virtual/libffi".
  (dependency required by "www-client/brave-bin-1.21.70::ninjatools" [ebuild])
  (dependency required by "brave-bin" [argument])
  chezmoi: exit status 1
  Beast-PC ~/.local/share/chezmoi #
```

It looks like it is a typo in ``libffi`` or ``virtual/libffi`` is outdated and it was removed... can't tell exactly.

Honestly.. I would continue to resolve these bugs once for all in this fork to able to pull this fork only once, but I am not experienced enough to do this bug, so I am letting experts continue this.